### PR TITLE
Fix UI: transparent background, centered zoom, improved zoom range

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -9,7 +9,7 @@ const CONFIG = {
     fov: 45,
     near: 0.1,
     far: 1000,
-    position: { x: 0, y: 0.05, z: 0.1 },  // Centered x, starting at max zoom (z=0.1)
+    position: { x: 0, y: 0.05, z: 0.15 },  // Centered x, starting at max zoom without going inside
     lookAt: { x: 0, y: 0.04, z: 0 }
   },
   colors: {
@@ -910,9 +910,9 @@ function onMouseWheel(event) {
   const zoomSpeed = 0.01;
   const direction = event.deltaY > 0 ? 1 : -1;
 
-  // Zoom range: 0.08 (max zoom, very close) to 0.6 (min zoom, far)
+  // Zoom range: 0.12 (max zoom, close but not inside) to 0.6 (min zoom, far)
   camera.position.z += direction * zoomSpeed;
-  camera.position.z = Math.max(0.08, Math.min(0.6, camera.position.z));
+  camera.position.z = Math.max(0.12, Math.min(0.6, camera.position.z));
 }
 
 async function onKeyDown(event) {


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request fixes issue #3 with the following UI improvements:

### 📋 Issue Reference
Fixes #3

### 📝 Changes Made

1. **Transparent Window Background**
   - Removed `scene.background` color to allow the Electron window's transparent setting to work properly
   - The Three.js scene now renders without a background color

2. **Fixed Zoom Center**
   - Changed camera position from `x: 0.15` to `x: 0` to center the view on the player
   - This fixes the issue where zooming caused the player to appear off-center (shifted to the left)

3. **Optimized Starting Zoom**
   - Changed initial camera position from `z: 0.35` to `z: 0.15` for a closer starting view
   - Adjusted to prevent camera from clipping inside the cassette body (based on user feedback)

4. **Increased Maximum Zoom Level**
   - Changed minimum z-distance from `0.15` to `0.12`
   - This allows users to zoom in closer while preventing camera from going inside the model
   - Zoom range is now `0.12` (max zoom) to `0.6` (min zoom)

### 🔧 Technical Details

All changes are in `src/renderer.js`:
- Camera initial position: `{ x: 0, y: 0.05, z: 0.15 }` (was `{ x: 0.15, y: 0.05, z: 0.35 }`)
- Scene background: removed (was `new THREE.Color(0x1a1a2e)`)
- Zoom range: `0.12` to `0.6` (was `0.15` to `0.6`)

### 📜 Commits
1. Initial UI fixes for transparency, centering, and zoom
2. Adjustment to prevent camera from being inside the body (based on feedback)

---
*This PR was created automatically by the AI issue solver*

🤖 Generated with [Claude Code](https://claude.com/claude-code)