### PR TITLE
Fix track title timing, appearance tab dimming, and slider scroll step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/cassette-sound-music-player/issues/15
-Your prepared branch: issue-15-530c1ca43f78
-Your prepared working directory: /tmp/gh-issue-solver-1767254504174
-Your forked repository: konard/Jhon-Crow-cassette-sound-music-player
-Original repository (upstream): Jhon-Crow/cassette-sound-music-player
-
-Proceed.


### PR DESCRIPTION
## Summary
This PR addresses all three issues mentioned in #15:

1. **Track title display timing**: The track title overlay at the top of the screen now appears when a track starts playing, not when a folder is added.

2. **Appearance tab visibility**: When switching to the Appearance tab in settings, the background dimming is removed so users can see visual changes to the background gradient in real-time.

3. **Slider scroll precision**: Moving sliders using scroll wheel now has a fixed step of 1 (e.g., 1%) for more precise control.

## Changes Made
- `src/renderer.js`:
  - Moved `showTrackOverlay()` call from `loadTrack()` to `play()` function
  - Added logic to remove overlay background when Appearance tab is active
  - Changed slider scroll step from 5% of range to fixed step of 1

## Test Plan
- [x] Load a folder of music files and verify track title does NOT appear until play is pressed
- [x] Open settings, switch to Appearance tab, and verify the background dimming disappears
- [x] Enable gradient in Appearance tab and verify changes are visible immediately
- [x] Use scroll wheel on any slider and verify it moves by exactly 1 unit per scroll

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)