### PR TITLE
скрывай системные кнопки раньше

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Jhon-Crow/cassette-sound-music-player/issues/36
+Your prepared branch: issue-36-80f97d020a87
+Your prepared working directory: /tmp/gh-issue-solver-1769211069532
+Your forked repository: konard/Jhon-Crow-cassette-sound-music-player
+Original repository (upstream): Jhon-Crow/cassette-sound-music-player
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/cassette-sound-music-player/issues/36
-Your prepared branch: issue-36-80f97d020a87
-Your prepared working directory: /tmp/gh-issue-solver-1769211069532
-Your forked repository: konard/Jhon-Crow-cassette-sound-music-player
-Original repository (upstream): Jhon-Crow/cassette-sound-music-player
-
-Proceed.

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -351,9 +351,10 @@ function updateBottomCaptionsVisibility() {
     statusBar.style.display = isSmallHeight ? 'none' : 'block';
   }
 
-  // Hide window controls when window is very small (height or width < 120px)
+  // Hide window controls when window is very small (height < 120px or width < 300px)
   const controlsThreshold = 120;
-  const isVerySmall = window.innerHeight < controlsThreshold || window.innerWidth < controlsThreshold;
+  const widthThreshold = 300;
+  const isVerySmall = window.innerHeight < controlsThreshold || window.innerWidth < widthThreshold;
 
   if (windowControls) {
     windowControls.style.display = isVerySmall ? 'none' : 'flex';


### PR DESCRIPTION
## 🤖 AI-Powered Solution

Fixes #36

### 📋 Summary

Updated the window controls (minimize, maximize, close buttons) to hide earlier when the window becomes narrow, matching the user's requirement.

### 🔧 Changes Made

**File**: `src/renderer.js:354-357`

Changed the window controls hiding threshold:
- **Before**: Controls hidden when width < 120px
- **After**: Controls hidden when width < 300px
- Height threshold remains at 120px

### 💡 Implementation Details

The window controls visibility is managed by the `updateBottomCaptionsVisibility()` function in `renderer.js`. The function checks window dimensions and hides controls when the window becomes too small.

Modified logic:
```javascript
// Hide window controls when window is very small (height < 120px or width < 300px)
const controlsThreshold = 120;
const widthThreshold = 300;
const isVerySmall = window.innerHeight < controlsThreshold || window.innerWidth < widthThreshold;
```

This ensures that:
1. System buttons hide when window width is less than 300px
2. System buttons also hide when window height is less than 120px  
3. Window controls display properly at wider window sizes to avoid UI crowding

### ✅ Testing

- The change has been verified to correctly update the width threshold from 120px to 300px
- No other functionality is affected by this change
- CI builds are running to ensure no regressions

---
*This PR was created automatically by the AI issue solver*